### PR TITLE
Marker Bugfix

### DIFF
--- a/client/src/components/LandingPage/LandingPage.js
+++ b/client/src/components/LandingPage/LandingPage.js
@@ -77,8 +77,8 @@ class LandingPage extends React.Component {
             return (
               <Marker
                 key={i}
-                latitude={mark.geometry.coordinates[0]}
-                longitude={mark.geometry.coordinates[1]}
+                latitude={mark.geometry.coordinates[1]}
+                longitude={mark.geometry.coordinates[0]}
               >
                 <ShowMarker>
                   <Pop>{mark.properties.title}</Pop>

--- a/server/seekers/seekersRouters.js
+++ b/server/seekers/seekersRouters.js
@@ -87,7 +87,9 @@ router.post('/addUser', (req, res) => {
   // Construct New Marker Object
   const markerData = {
     geometry: {
-      coordinates: location.coordinates,
+
+      // Convert Coordinates to Numbers
+      coordinates: location.coordinates.map(coord => Number(coord)),
       type: 'Point',
     },
     properties: {


### PR DESCRIPTION
# Description

**Switch Latitude and Longitude**
- Marker Latitude and Longitude were backwards. I have switched
  them so that they render the correct coordinates.

- I also updated the database markers with coordinates that work
  either way to allow development while waiting for this to be
  merged.


**Convert Coords to Number in Server**
- Currently the server will store coordinates as strings in the
  database if strings are passed to it. This converts coordinates
  passed as strings to numbers.

- Markers give a type error if passed strings, even though the
  markers still render due to coercion. This is intended to fix
  that type error, which had been repeatedly showing up.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Change status
- [x] Complete, tested, ready to review and merge

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A: Tested a verified location latitude and longitude to make sure that the location is correct.
- [ ] Test B: Passed coordinates as strings and verified that they were converted to numbers in the database.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My code has been reviewed by at least one peer
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] There are no merge conflicts